### PR TITLE
feat: Add a cookie notice.

### DIFF
--- a/data/SiteConfig.js
+++ b/data/SiteConfig.js
@@ -36,10 +36,9 @@ const config = {
   matomoOptions: {
     siteId: '6',
     matomoUrl: 'https://analytics.octopusth.ink',
-    siteUrl: 'https://octopusthink.com',
-    requireConsent: false,
-    // Removes the need for cookie notices and is less creepy! :-)
-    disableCookies: true,
+    siteUrl: 'https://getmicdrop.com',
+    requireConsent: true,
+    dev: process.env.NODE_ENV !== 'production',
   },
   // Replace this with a Nautilus Theme object.
   // See: https://nautilus.octopusthink.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1820,6 +1820,11 @@
       "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-2.1.1.tgz",
       "integrity": "sha1-zR6FU2M60xhcPy8jns/10mQ+krY="
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/debug": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
@@ -1854,6 +1859,15 @@
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
       "integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw=="
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -1912,6 +1926,11 @@
       "version": "13.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
       "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+    },
+    "@types/object-assign": {
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
+      "integrity": "sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -15944,6 +15963,16 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-cookie": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.0.3.tgz",
+      "integrity": "sha512-cmi6IpdVgTSvjqssqIEvo779Gfqc4uPGHRrKMEdHcqkmGtPmxolGfsyKj95bhdLEKqMdbX8MLBCwezlnhkHK0g==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-dev-utils": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-4.2.3.tgz",
@@ -19531,6 +19560,17 @@
       "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
       "requires": {
         "unist-util-is": "^3.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.3.tgz",
+      "integrity": "sha512-YbEHRs7bYOBTIWedTR9koVEe2mXrq+xdjTJZcoKJK/pQaE6ni28ak2AKXFpevb+X6w3iU5SXzWDiJkmpDRb9qw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "@types/object-assign": "^4.0.30",
+        "cookie": "^0.4.0",
+        "object-assign": "^4.1.1"
       }
     },
     "universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1574,7 +1574,7 @@
       }
     },
     "@octopusthink/nautilus": {
-      "version": "github:octopusthink/nautilus#454f33a97f2031ac6e745dd2246277673defc62f",
+      "version": "github:octopusthink/nautilus#5b9e6fcd79d201598d5d15012aec445a389e400c",
       "from": "github:octopusthink/nautilus",
       "requires": {
         "chroma-js": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1574,7 +1574,7 @@
       }
     },
     "@octopusthink/nautilus": {
-      "version": "github:octopusthink/nautilus#5b9e6fcd79d201598d5d15012aec445a389e400c",
+      "version": "github:octopusthink/nautilus#454f33a97f2031ac6e745dd2246277673defc62f",
       "from": "github:octopusthink/nautilus",
       "requires": {
         "chroma-js": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@mdx-js/react": "^1.5.1",
     "@octopusthink/nautilus": "github:octopusthink/nautilus",
     "@use-it/event-listener": "^0.1.3",
-    "a11y-react-emoji": "^1.1.1",
+    "a11y-react-emoji": "^1.1.2",
     "acorn": "^7.1.0",
     "babel-jest": "^24.8.0",
     "babel-preset-gatsby": "^0.2.17",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "pluralize": "^8.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
+    "react-cookie": "^4.0.3",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.1",
     "react-test-renderer": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@octopusthink/getmicdrop.com",
-  "description": "The Octopus Think blog + site starter for Gatsby",
-  "version": "0.2.0",
+  "description": "Mic Drop website",
+  "version": "1.0.0",
+  "private": true,
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",

--- a/src/components/CTAButtons/index.js
+++ b/src/components/CTAButtons/index.js
@@ -3,9 +3,15 @@ import { css } from '@emotion/core';
 import React, { Fragment } from 'react';
 import { Helmet } from 'react-helmet';
 
-const CTAButtons = () => {
+import { trackEvent } from '../../utils/eventTracking';
+
+const CTAButtons = (props) => {
+  const { source } = props;
+
   const openPaddle = (event) => {
     event.preventDefault();
+
+    trackEvent('Purchase-Started', source ? `Buy-Button-${source}` : 'Buy-Button');
 
     if (!global.Paddle) {
       global.console.warn('Paddle global not available.');
@@ -14,10 +20,18 @@ const CTAButtons = () => {
 
     global.Paddle.Setup({ vendor: 104629 });
     global.Paddle.Checkout.open({
-      message:
-        "50% of sales go to Scottish Women's Aid to help keep vulnerable people safe during the current pandemic.",
+      closeCallback: () => {
+        trackEvent('Purchase-Cancelled', source ? `Buy-Button-${source}` : 'Buy-Button');
+      },
+      successCallback: () => {
+        trackEvent('Purchase-Complete', source ? `Buy-Button-${source}` : 'Buy-Button');
+      },
       product: 576284,
     });
+  };
+
+  const trackDownload = () => {
+    trackEvent('Download', source ? `Trial-Button-${source}` : 'Trial-Button');
   };
 
   return (
@@ -30,7 +44,7 @@ const CTAButtons = () => {
           margin-bottom: 2.4rem;
         `}
       >
-        <Button as="a" href="/downloads/Mic%20Drop%201.0.0.zip" navigation>
+        <Button as="a" href="/downloads/Mic%20Drop%201.0.0.zip" navigation onClick={trackDownload}>
           Free Download
         </Button>
         <Button onClick={openPaddle} primary>

--- a/src/components/CookieNotice/index.js
+++ b/src/components/CookieNotice/index.js
@@ -1,9 +1,18 @@
-import { Link, Paragraph, useTheme } from '@octopusthink/nautilus';
-import React from 'react';
 import { css } from '@emotion/core';
+import { Link, Paragraph, useTheme } from '@octopusthink/nautilus';
+import Emoji from 'a11y-react-emoji';
+import React from 'react';
 
 const CookieNotice = () => {
   const theme = useTheme();
+
+  const allowCookies = (event) => {
+    event.preventDefault();
+  };
+
+  const refuseCookies = (event) => {
+    event.preventDefault();
+  };
 
   return (
     <div
@@ -29,7 +38,6 @@ const CookieNotice = () => {
         }
 
         a {
-          box-shadow: 0 1px ${theme.colors.neutral.grey200};
           color: ${theme.colors.neutral.white};
           margin-right: 4px;
 
@@ -40,8 +48,8 @@ const CookieNotice = () => {
       `}
     >
       <Paragraph inverse small>
-        Hi there! 👋 Are you cool with letting our analytics program know you've visited? We promise
-        to protect your privacy and we'll never sell your information to advertisers.
+        <Emoji label="Hi there!" symbol="👋" /> Are you okay with us using cookies? We promise to
+        protect your privacy and we&apos;ll never sell your information to advertisers.
       </Paragraph>
 
       <Paragraph
@@ -53,8 +61,12 @@ const CookieNotice = () => {
           justify-content: space-between;
         `}
       >
-        <Link>Yes, that's fine.</Link>
-        <Link>No thank you.</Link>
+        <Link as="a" href="#no-cookies" onClick={refuseCookies}>
+          No thanks.
+        </Link>
+        <Link as="a" href="#cookies-are-tasty" onClick={allowCookies}>
+          Yes, that&apos;s fine.
+        </Link>
       </Paragraph>
     </div>
   );

--- a/src/components/CookieNotice/index.js
+++ b/src/components/CookieNotice/index.js
@@ -1,0 +1,63 @@
+import { Link, Paragraph, useTheme } from '@octopusthink/nautilus';
+import React from 'react';
+import { css } from '@emotion/core';
+
+const CookieNotice = () => {
+  const theme = useTheme();
+
+  return (
+    <div
+      css={css`
+        background: ${theme.colors.neutral.black};
+        padding: 2.4rem;
+        position: fixed;
+        text-align: left;
+        z-index: 20;
+
+        @media screen and (max-width: 639px) {
+          border-top: 2px solid ${theme.colors.neutral.white};
+          left: 0;
+          bottom: 0;
+          right: 0;
+        }
+
+        @media screen and (min-width: 640px) {
+          border: 2px solid ${theme.colors.neutral.white};
+          left: 4.8rem;
+          top: 4.8rem;
+          max-width: 320px;
+        }
+
+        a {
+          box-shadow: 0 1px ${theme.colors.neutral.grey200};
+          color: ${theme.colors.neutral.white};
+          margin-right: 4px;
+
+          &:hover {
+            color: ${theme.colors.neutral.white};
+          }
+        }
+      `}
+    >
+      <Paragraph inverse small>
+        Hi there! 👋 Are you cool with letting our analytics program know you've visited? We promise
+        to protect your privacy and we'll never sell your information to advertisers.
+      </Paragraph>
+
+      <Paragraph
+        noMargin
+        inverse
+        small
+        css={css`
+          display: flex;
+          justify-content: space-between;
+        `}
+      >
+        <Link>Yes, that's fine.</Link>
+        <Link>No thank you.</Link>
+      </Paragraph>
+    </div>
+  );
+};
+
+export default CookieNotice;

--- a/src/components/HomepageCTA/index.js
+++ b/src/components/HomepageCTA/index.js
@@ -1,11 +1,16 @@
-import { Heading, Paragraph, useTheme } from '@octopusthink/nautilus';
+import { Heading, Link, Paragraph, useTheme } from '@octopusthink/nautilus';
 import { css } from '@emotion/core';
 import React from 'react';
 
 import CTAButtons from 'components/CTAButtons';
+import { trackEvent } from '../../utils/eventTracking';
 
 const HomepageCTA = () => {
   const theme = useTheme();
+
+  const trackMASLink = () => {
+    trackEvent('MacAppStore-Click', 'Header');
+  };
 
   return (
     <div
@@ -33,10 +38,25 @@ const HomepageCTA = () => {
         menu bar control
       </Heading>
 
-      <CTAButtons />
+      <CTAButtons source="Header" />
 
       <Paragraph inverse small>
-        {/* Also available on the Mac App Store. <br /> */}
+        Also{' '}
+        <Link
+          as="a"
+          css={css`
+            &,
+            &:hover,
+            &:focus {
+              color: ${theme.colors.text.inverseLight};
+            }
+          `}
+          href="https://apps.apple.com/app/mic-drop/id1489816366"
+          onClick={trackMASLink}
+        >
+          available on the Mac App Store
+        </Link>
+        . <br />
         Requires macOS 10.15 Catalina.
       </Paragraph>
     </div>

--- a/src/components/SiteFooter/index.js
+++ b/src/components/SiteFooter/index.js
@@ -2,45 +2,40 @@ import { css } from '@emotion/core';
 import { Link, Paragraph, useTheme } from '@octopusthink/nautilus';
 import React from 'react';
 
-import CookieNotice from 'components/CookieNotice';
-
 const SiteFooter = () => {
   const theme = useTheme();
 
   return (
-    <React.Fragment>
-      <footer
-        css={css`
-          width: 100%;
-          margin: 8rem auto 0;
-          padding: 2.4rem 0 1.6rem;
-          max-width: ${theme.site.maxContentWidth};
-          text-align: center;
-        `}
-      >
-        <Paragraph small>
-          Made with{' '}
-          <span role="img" aria-label="love">
-            ❤️
-          </span>{' '}
-          and{' '}
-          <span role="img" aria-label="cephalopods">
-            🐙
-          </span>{' '}
-          by{' '}
-          <Link as="a" href="https://octopusthink.com">
-            Octopus Think
-          </Link>
-          {/* eslint-disable-next-line react/jsx-curly-brace-presence */}
-          {` · `}
-          <Link to="/privacy">Privacy</Link>
-          {/* eslint-disable-next-line react/jsx-curly-brace-presence */}
-          {` · `}
-          <Link to="/credits">Credits</Link>
-        </Paragraph>
-      </footer>
-      <CookieNotice />
-    </React.Fragment>
+    <footer
+      css={css`
+        width: 100%;
+        margin: 8rem auto 0;
+        padding: 2.4rem 0 1.6rem;
+        max-width: ${theme.site.maxContentWidth};
+        text-align: center;
+      `}
+    >
+      <Paragraph small>
+        Made with{' '}
+        <span role="img" aria-label="love">
+          ❤️
+        </span>{' '}
+        and{' '}
+        <span role="img" aria-label="cephalopods">
+          🐙
+        </span>{' '}
+        by{' '}
+        <Link as="a" href="https://octopusthink.com">
+          Octopus Think
+        </Link>
+        {/* eslint-disable-next-line react/jsx-curly-brace-presence */}
+        {` · `}
+        <Link to="/privacy">Privacy</Link>
+        {/* eslint-disable-next-line react/jsx-curly-brace-presence */}
+        {` · `}
+        <Link to="/credits">Credits</Link>
+      </Paragraph>
+    </footer>
   );
 };
 

--- a/src/components/SiteFooter/index.js
+++ b/src/components/SiteFooter/index.js
@@ -2,40 +2,45 @@ import { css } from '@emotion/core';
 import { Link, Paragraph, useTheme } from '@octopusthink/nautilus';
 import React from 'react';
 
+import CookieNotice from 'components/CookieNotice';
+
 const SiteFooter = () => {
   const theme = useTheme();
 
   return (
-    <footer
-      css={css`
-        width: 100%;
-        margin: 8rem auto 0;
-        padding: 2.4rem 0 1.6rem;
-        max-width: ${theme.site.maxContentWidth};
-        text-align: center;
-      `}
-    >
-      <Paragraph small>
-        Made with{' '}
-        <span role="img" aria-label="love">
-          ❤️
-        </span>{' '}
-        and{' '}
-        <span role="img" aria-label="cephalopods">
-          🐙
-        </span>{' '}
-        by{' '}
-        <Link as="a" href="https://octopusthink.com">
-          Octopus Think
-        </Link>
-        {/* eslint-disable-next-line react/jsx-curly-brace-presence */}
-        {` · `}
-        <Link to="/privacy">Privacy</Link>
-        {/* eslint-disable-next-line react/jsx-curly-brace-presence */}
-        {` · `}
-        <Link to="/credits">Credits</Link>
-      </Paragraph>
-    </footer>
+    <React.Fragment>
+      <footer
+        css={css`
+          width: 100%;
+          margin: 8rem auto 0;
+          padding: 2.4rem 0 1.6rem;
+          max-width: ${theme.site.maxContentWidth};
+          text-align: center;
+        `}
+      >
+        <Paragraph small>
+          Made with{' '}
+          <span role="img" aria-label="love">
+            ❤️
+          </span>{' '}
+          and{' '}
+          <span role="img" aria-label="cephalopods">
+            🐙
+          </span>{' '}
+          by{' '}
+          <Link as="a" href="https://octopusthink.com">
+            Octopus Think
+          </Link>
+          {/* eslint-disable-next-line react/jsx-curly-brace-presence */}
+          {` · `}
+          <Link to="/privacy">Privacy</Link>
+          {/* eslint-disable-next-line react/jsx-curly-brace-presence */}
+          {` · `}
+          <Link to="/credits">Credits</Link>
+        </Paragraph>
+      </footer>
+      <CookieNotice />
+    </React.Fragment>
   );
 };
 

--- a/src/content/pages/index.mdx
+++ b/src/content/pages/index.mdx
@@ -82,7 +82,7 @@ Is this thing on? Can you hear me now? A clear indicator means you’ll never as
 
 We can't promise to keep your overly-enthusiastic co-worker from cutting you off, but we _can_ make it a little bit easier to control your sound.
 
-<CTAButtons />
+<CTAButtons source="Footer" />
 
 </TextBlock>
 

--- a/src/templates/App.js
+++ b/src/templates/App.js
@@ -3,6 +3,7 @@ import { useTheme } from '@octopusthink/nautilus';
 import React from 'react';
 import 'typeface-inter';
 
+import CookieNotice from 'components/CookieNotice';
 import GhostShipMDX from 'components/GhostShipMDX';
 import SiteHeader from 'components/SiteHeader';
 import SiteFooter from 'components/SiteFooter';
@@ -38,6 +39,7 @@ export const App = (props) => {
         </main>
         <SiteFooter />
       </div>
+      <CookieNotice />
     </GhostShipMDX>
   );
 };

--- a/src/templates/App.js
+++ b/src/templates/App.js
@@ -1,6 +1,6 @@
 import { css, Global } from '@emotion/core';
 import { useTheme } from '@octopusthink/nautilus';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { CookiesProvider } from 'react-cookie';
 import 'typeface-inter';
 
@@ -8,17 +8,10 @@ import CookieNotice from 'components/CookieNotice';
 import GhostShipMDX from 'components/GhostShipMDX';
 import SiteHeader from 'components/SiteHeader';
 import SiteFooter from 'components/SiteFooter';
-// import { giveConsent, setupAnalytics } from '../utils/eventTracking';
-import { setupAnalytics } from '../utils/eventTracking';
 
 export const App = (props) => {
   const { children, homepage } = props;
   const theme = useTheme();
-
-  useEffect(() => {
-    setupAnalytics();
-    // giveConsent();
-  }, []);
 
   return (
     <CookiesProvider>

--- a/src/templates/App.js
+++ b/src/templates/App.js
@@ -1,46 +1,56 @@
 import { css, Global } from '@emotion/core';
 import { useTheme } from '@octopusthink/nautilus';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { CookiesProvider } from 'react-cookie';
 import 'typeface-inter';
 
 import CookieNotice from 'components/CookieNotice';
 import GhostShipMDX from 'components/GhostShipMDX';
 import SiteHeader from 'components/SiteHeader';
 import SiteFooter from 'components/SiteFooter';
+// import { giveConsent, setupAnalytics } from '../utils/eventTracking';
+import { setupAnalytics } from '../utils/eventTracking';
 
 export const App = (props) => {
   const { children, homepage } = props;
   const theme = useTheme();
 
+  useEffect(() => {
+    setupAnalytics();
+    // giveConsent();
+  }, []);
+
   return (
-    <GhostShipMDX>
-      <Global
-        styles={css`
-          body {
-            background: ${theme.colors.neutral.white};
-            margin: 0;
-            letter-spacing: -0.02em;
-          }
-        `}
-      />
-      <div
-        css={css`
-          margin: 0 auto;
-        `}
-      >
-        <SiteHeader homepage={homepage} />
-        <main
-          id="content"
+    <CookiesProvider>
+      <GhostShipMDX>
+        <Global
+          styles={css`
+            body {
+              background: ${theme.colors.neutral.white};
+              margin: 0;
+              letter-spacing: -0.02em;
+            }
+          `}
+        />
+        <div
           css={css`
-            margin: 0 auto 4.8rem;
+            margin: 0 auto;
           `}
         >
-          {children}
-        </main>
-        <SiteFooter />
-      </div>
-      <CookieNotice />
-    </GhostShipMDX>
+          <SiteHeader homepage={homepage} />
+          <main
+            id="content"
+            css={css`
+              margin: 0 auto 4.8rem;
+            `}
+          >
+            {children}
+          </main>
+          <SiteFooter />
+        </div>
+        <CookieNotice />
+      </GhostShipMDX>
+    </CookiesProvider>
   );
 };
 

--- a/src/utils/eventTracking.js
+++ b/src/utils/eventTracking.js
@@ -1,4 +1,4 @@
-export const setupAnalytics = () => {
+export const setupAnalytics = ({ consentGiven = false } = {}) => {
   const { console, _paq } = global;
 
   if (!_paq) {
@@ -8,22 +8,10 @@ export const setupAnalytics = () => {
 
   _paq.push(['alwaysUseSendBeacon']);
   _paq.push(['enableLinkTracking']);
-};
 
-export const giveConsent = (setCookie) => {
-  const { console, _paq } = global;
-  if (!_paq) {
-    console.warn('Matomo JS global not available.');
-    return;
+  if (consentGiven) {
+    _paq.push(['setConsentGiven']);
   }
-
-  if (!setCookie) {
-    console.error('setCookie function is required.');
-    return;
-  }
-
-  setCookie('analyticsConsent', true, { path: '/' });
-  _paq.push(['setConsentGiven']);
 };
 
 export const trackEvent = (name, ...values) => {

--- a/src/utils/eventTracking.js
+++ b/src/utils/eventTracking.js
@@ -1,0 +1,37 @@
+export const setupAnalytics = () => {
+  const { console, _paq } = global;
+
+  if (!_paq) {
+    console.warn('Matomo JS global not available.');
+    return;
+  }
+
+  _paq.push(['alwaysUseSendBeacon']);
+  _paq.push(['enableLinkTracking']);
+};
+
+export const giveConsent = (setCookie) => {
+  const { console, _paq } = global;
+  if (!_paq) {
+    console.warn('Matomo JS global not available.');
+    return;
+  }
+
+  if (!setCookie) {
+    console.error('setCookie function is required.');
+    return;
+  }
+
+  setCookie('analyticsConsent', true, { path: '/' });
+  _paq.push(['setConsentGiven']);
+};
+
+export const trackEvent = (name, ...values) => {
+  const { console, _paq } = global;
+  if (!_paq) {
+    console.warn('Matomo JS global not available.');
+    return;
+  }
+
+  _paq.push(['trackEvent', name, ...values]);
+};


### PR DESCRIPTION
<img width="1000" alt="Screenshot 2020-04-15 at 12 25 27" src="https://user-images.githubusercontent.com/376315/79332331-912de900-7f14-11ea-95b6-580d7be56d35.png">

@tofumatt want to hook this up? It's not perfect, but it works nicely on mobile and desktop resolutions, which I'd wager are 90% of the people who aren't me visiting the site right now. I'll optimise it better soon. 

Also, we could probably cut down the text a bit by linking to the privacy policy, which we should expand with a section about how we use cookies (and also how to reject them or allow them after the fact.)

Fix #34.