### PR TITLE
feat: Add product roadmap

### DIFF
--- a/src/components/NewsletterSignupForm/index.js
+++ b/src/components/NewsletterSignupForm/index.js
@@ -45,7 +45,7 @@ const NewsletterSignupForm = (props) => {
           `}
         />
         <input type="hidden" value="1" name="embed" />
-        <input type="hidden" name="tag" value="from-getmicdrop.com  octopus-thoughts" />
+        <input type="hidden" name="tag" value="from-getmicdrop.com octopus-thoughts" />
       </div>
       <Button
         css={css`

--- a/src/components/NewsletterSignupForm/index.js
+++ b/src/components/NewsletterSignupForm/index.js
@@ -45,7 +45,7 @@ const NewsletterSignupForm = (props) => {
           `}
         />
         <input type="hidden" value="1" name="embed" />
-        <input type="hidden" name="tag" value="from-getmicdrop.com, octopus-thoughts" />
+        <input type="hidden" name="tag" value="from-getmicdrop.com  octopus-thoughts" />
       </div>
       <Button
         css={css`

--- a/src/components/Panel/index.js
+++ b/src/components/Panel/index.js
@@ -20,11 +20,20 @@ const Panel = (props) => {
     gridDesktop,
     gridWide,
     negativeMargins,
+    verticalAlignment,
   } = props;
 
   let hasGrid = false;
   if (gridMobile || gridTablet || gridDesktop || gridWide) {
     hasGrid = true;
+  }
+
+  let alignItems = 'center';
+  if (verticalAlignment === 'top') {
+    alignItems = 'flex-start';
+  }
+  if (verticalAlignment === 'bottom') {
+    alignItems = 'flex-end';
   }
 
   const panelBackground = dark ? theme.colors.neutral.black : 'transparent';
@@ -154,7 +163,7 @@ const Panel = (props) => {
                 css`
                   display: grid;
                   grid-template-columns: ${gridMobile};
-                  align-items: center;
+                  align-items: ${alignItems};
                   height: 100%;
                 `}
             }
@@ -165,7 +174,7 @@ const Panel = (props) => {
                 css`
                   display: grid;
                   grid-template-columns: ${gridTablet};
-                  align-items: center;
+                  align-items: ${alignItems};
                   height: 100%;
                 `}
             }
@@ -176,7 +185,7 @@ const Panel = (props) => {
                 css`
                   display: grid;
                   grid-template-columns: ${gridDesktop};
-                  align-items: center;
+                  align-items: ${alignItems};
                   height: 100%;
                 `}
             }
@@ -186,7 +195,7 @@ const Panel = (props) => {
                 css`
                   display: grid;
                   grid-template-columns: ${gridWide};
-                  align-items: center;
+                  align-items: ${alignItems};
                   height: 100%;
                 `}
             }

--- a/src/components/SiteMap/index.js
+++ b/src/components/SiteMap/index.js
@@ -21,6 +21,7 @@ const SiteMap = (props) => {
         `}
       >
         <ListLink link="/">Home</ListLink>
+        <ListLink link="/roadmap/">Roadmap</ListLink>
         <ListLink link="/under-the-hood/">How it’s made</ListLink>
         <ListLink link="/privacy/">Privacy</ListLink>
         <ListLink link="/credits/">Credits</ListLink>

--- a/src/content/pages/help/index.mdx
+++ b/src/content/pages/help/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Help!
+title: Help & FAQ
 
 ---
 
@@ -12,13 +12,17 @@ Got a question about Mic Drop? We've done our best to design the app so that it'
 If you can't find the answer to your question here, please drop us a line via [email](mailto:help@getmicdrop.com) or [Twitter](https://twitter.com/octopusthinks) and we'll get back to you lickety-split.
 
 ## Getting started
-- Giving Mic Drop [permissions](/help/permissions)
-- Setting a [keyboard shortcut](/help/keyboard-shortcut)
-- [Software compatibility](/help/compatibility)
+- 👮🏿‍♀️ How do I give Mic Drop [permissions](/help/permissions)?
+- ⌨️ How do I configure my [keyboard shortcut?](/help/keyboard-shortcut)
+- 🍦 What [software](/help/compatibility) does Mic Drop work with?
 
 ## Advanced features
-- Known [hardware issues](/help/hardware-issues)
-- Using [push-to-talk](/help/push-to-talk)
-- Our stance on [privacy](/privacy)
+- 🎙 Is Mic Drop [compatible with my audio device?](/help/hardware-issues)
+- 📢 How do I use [push-to-talk](/help/push-to-talk)?
+
+## About Mic Drop
+- 🐛 How do I [suggest a feature](mailto:help@getmicdrop.com) or [report a bug](mailto:help@getmicdrop.com)?
+- 🛵 What's on your [roadmap?](/roadmap)
+- 👁 What's your stance on [privacy](/privacy)?
 
 </Panel>

--- a/src/content/pages/index.mdx
+++ b/src/content/pages/index.mdx
@@ -148,7 +148,7 @@ There are probably already more than enough machines in your house spying on you
 
 ## Your purchase supports charity
 
-In 2020, we donated 50% of every sale to charities affected by COVID-19:  [Scottish Women's Aid](https://womensaid.scot/covid-19/) and [Scottish Refugee Council](https://www.scottishrefugeecouncil.org.uk).
+In 2020, we donated 50% of every sale to charities affected by COVID-19:  [Scottish Women's Aid](https://womensaid.scot/covid-19/), [Scottish Refugee Council](https://www.scottishrefugeecouncil.org.uk), and [Shelter](https://scotland.shelter.org.uk/).
 
 For 2021, Octopus Think has [pledged to donate](https://www.instagram.com/p/CJojqkZJluk/) at least 1% of all revenues to charitable organisations.
 

--- a/src/content/pages/index.mdx
+++ b/src/content/pages/index.mdx
@@ -148,9 +148,9 @@ There are probably already more than enough machines in your house spying on you
 
 ## Your purchase supports charity
 
-In 2020, we're donating 50% of every sale to charities affected by COVID-19.
+In 2020, we donated 50% of every sale to charities affected by COVID-19:  [Scottish Women's Aid](https://womensaid.scot/covid-19/) and [Scottish Refugee Council](https://www.scottishrefugeecouncil.org.uk).
 
-So far, we've donated to [Scottish Women's Aid](https://womensaid.scot/covid-19/) and [Scottish Refugee Council](https://www.scottishrefugeecouncil.org.uk).
+For 2021, Octopus Think has [pledged to donate](https://www.instagram.com/p/CJojqkZJluk/) at least 1% of all revenues to charitable organisations.
 
 </TextBlock>
 

--- a/src/content/pages/index.mdx
+++ b/src/content/pages/index.mdx
@@ -148,9 +148,9 @@ There are probably already more than enough machines in your house spying on you
 
 ## Your purchase supports charity
 
-In 2020, we donated 50% of every sale to charities affected by COVID-19:  [Scottish Women's Aid](https://womensaid.scot/covid-19/), [Scottish Refugee Council](https://www.scottishrefugeecouncil.org.uk), and [Shelter](https://scotland.shelter.org.uk/).
+In 2020, we donated 50% of every sale to charities affected by COVID-19: [Scottish Women's Aid](https://womensaid.scot/covid-19/), [Scottish Refugee Council](https://www.scottishrefugeecouncil.org.uk), and [Shelter Scotland](https://scotland.shelter.org.uk/).
 
-For 2021, Octopus Think has [pledged to donate](https://www.instagram.com/p/CJojqkZJluk/) at least 1% of all revenues to charitable organisations.
+For 2021, we've [pledged to donate](https://www.instagram.com/p/CJojqkZJluk/) at least 1% of all profits to charitable organisations.
 
 </TextBlock>
 

--- a/src/content/pages/roadmap.mdx
+++ b/src/content/pages/roadmap.mdx
@@ -1,0 +1,38 @@
+---
+title: What we're working on
+---
+
+import { Icon as NautilusIcon, Link } from '@octopusthink/nautilus';
+import Panel from 'components/Panel';
+
+<Panel>
+
+Mic Drop is under active development. We try to be deliberate and thoughtful in how we release new features, which means we don't have specific timelines for any of the planned improvements listed below. 
+
+We prioritise features and improvements based on user feedback. If there's anything you think would make Mic Drop better, please <Link href="mailto:support@getmicdrop.com">drop us a line</Link> and let us know! We ❤️ hearing from you.
+
+</Panel>
+
+<Panel gridTablet="1fr 1fr" verticalAlignment="top" className="roadmap">
+
+<div>
+
+## Coming soon-ish
+
+- <NautilusIcon name="square" />Improved status window
+- <NautilusIcon name="square" />Push-to-talk toggle
+- <NautilusIcon name="square" />Mute notifications
+- <NautilusIcon name="square" />Internationalisation
+
+</div>
+
+<div>
+
+## Shipped
+- <NautilusIcon name="check-square" color="green" />Accessibility improvements
+- <NautilusIcon name="check-square" color="green" />Resizable status window
+- <NautilusIcon name="check-square" color="green" />Big Sur and ARM Mac support
+
+</div>
+
+</Panel>

--- a/src/content/pages/roadmap.mdx
+++ b/src/content/pages/roadmap.mdx
@@ -7,7 +7,7 @@ import Panel from 'components/Panel';
 
 <Panel>
 
-Mic Drop is under active development. We try to be deliberate and thoughtful in how we release new features, which means we don't have specific timelines for any of the planned improvements listed below. 
+Mic Drop is under active development. We try to be deliberate and thoughtful about new features, which means we don't have specific timelines for any of the planned improvements listed below.
 
 We prioritise features and improvements based on user feedback. If there's anything you think would make Mic Drop better, please <Link href="mailto:support@getmicdrop.com">drop us a line</Link> and let us know! We ❤️ hearing from you.
 

--- a/src/templates/App.js
+++ b/src/templates/App.js
@@ -46,6 +46,16 @@ export const App = (props) => {
             ol + h3 {
               padding-top: 3.2rem;
             }
+
+            .roadmap li:before {
+              display: none;
+            }
+
+            .roadmap .Nautilus-Icon--square,
+            .roadmap .Nautilus-Icon--check-square {
+              vertical-align: -6px;
+              margin-right: 0.4rem;
+            }
           `}
         />
         <div


### PR DESCRIPTION
This adds a roadmap so users are aware of what's "on our list",

<img width="1257" alt="Screenshot 2021-01-11 at 22 05 46" src="https://user-images.githubusercontent.com/376315/104243858-2a187300-5459-11eb-95b1-b0f32f428a36.png">

It could probably be made prettier in the future, but let's get the content sorted first and then I can work to finesse it later.

I've also included a few other wee changes:

- Updates the charitable donations section for 2021, only 11 days later.
- Reframes the help section as an FAQ. (I also have a bunch of documentation to write to flesh this out, so I can handle it as a separate PR if that would be easier to review & approve!)
- Tests out a small change to the email signup form (basically adding dual tags isn't working right, but I'm struggling to test it locally).
